### PR TITLE
fix(tests): resolve goroutine-unsafe t.Error and no-op retry assertion

### DIFF
--- a/internal/algorithms/algorithms_test.go
+++ b/internal/algorithms/algorithms_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/karthikeyansura/ha-l7-lb/internal/repository"
@@ -74,17 +75,22 @@ func TestRoundRobin_ConcurrentSafety(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/", nil)
 
 	var wg sync.WaitGroup
+	var errCount atomic.Int64
 	for i := 0; i < 100; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			_, err := rr.GetTarget(&pool, req)
 			if err != nil {
-				t.Error(err)
+				errCount.Add(1)
 			}
 		}()
 	}
 	wg.Wait()
+
+	if errCount.Load() > 0 {
+		t.Errorf("expected 0 errors from concurrent GetTarget, got %d", errCount.Load())
+	}
 }
 
 // --- LeastConnections ---

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -116,11 +116,12 @@ func TestProxy_RetriesIdempotentOnFailure(t *testing.T) {
 
 	proxy.ServeHTTP(w, req)
 
-	// The request should eventually succeed via retry on backend2
-	if w.Code != http.StatusOK && callCount == 0 {
-		// If the first backend selected was backend2, it succeeds immediately.
-		// If backend1 was selected first, it should retry on backend2.
-		t.Logf("response code: %d, backend2 calls: %d", w.Code, callCount)
+	// backend2 must have been called (either directly or via retry).
+	if callCount == 0 {
+		t.Errorf("expected backend2 to be called at least once, got callCount=0")
+	}
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 OK (via direct hit or retry), got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
Resolves #23

Resolves a data race in `TestRoundRobin_ConcurrentSafety` where `t.Error` is called from child goroutines. Fixes a no-op test assertion in `TestProxy_RetriesIdempotentOnFailure`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 53ab709db7a0e2d0de2cd453191769441ad75b3a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->