### PR TITLE
fix(discovery): stop ticker on context cancellation to prevent resource leak

### DIFF
--- a/internal/discovery/dns.go
+++ b/internal/discovery/dns.go
@@ -18,7 +18,8 @@ import (
 func StartDNSWatcher(ctx context.Context, targetHostname, port, scheme string, defaultWeight int, pool repository.SharedState) {
 	ticker := time.NewTicker(5 * time.Second)
 	go func() {
-		// Initial sync
+		defer ticker.Stop()
+
 		syncDNS(targetHostname, port, scheme, defaultWeight, pool)
 
 		for {


### PR DESCRIPTION
Resolves #20

Adds `defer ticker.Stop()` to `StartDNSWatcher` to prevent leaking the ticker timer when the context is cancelled.