### PR TITLE
fix(redis): add periodic state sync to heal missed Pub/Sub events

### DIFF
--- a/cmd/lb/main.go
+++ b/cmd/lb/main.go
@@ -121,6 +121,9 @@ func main() {
 			// were already marked DOWN by other LB instances).
 			redisMgr.SyncOnStartUp()
 
+			// Periodic re-sync heals missed Pub/Sub messages.
+			redisMgr.StartPeriodicSync(context.Background(), 30*time.Second)
+
 			// Subscribe to Pub/Sub for real-time cross-instance health updates.
 			redisMgr.StartRedisWatcher()
 

--- a/internal/repository/redismanager/redis.go
+++ b/internal/repository/redismanager/redis.go
@@ -157,6 +157,24 @@ func (rm *RedisManager) SyncOnStartUp() {
 	}
 }
 
+// StartPeriodicSync runs SyncOnStartUp on a background ticker to heal
+// any state divergence caused by missed Pub/Sub messages. This enforces
+// eventual consistency without relying solely on fire-and-forget Pub/Sub.
+func (rm *RedisManager) StartPeriodicSync(ctx context.Context, interval time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				rm.SyncOnStartUp()
+			}
+		}
+	}()
+}
+
 // StartRedisWatcher launches a background goroutine that subscribes to
 // the Pub/Sub channel and applies incoming health state changes to
 // the local InMemory pool.


### PR DESCRIPTION
Resolves #7

Redis Pub/Sub is fire-and-forget — a momentary network blip causes permanent state divergence. This adds a `StartPeriodicSync` method that re-runs `SyncOnStartUp()` on a background ticker to enforce eventual consistency without heavy overhead.