### PR TITLE
fix(proxy): return 500 on body close failure instead of silent drop

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -82,6 +82,7 @@ func (lb *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		err := r.Body.Close()
 		if err != nil {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 	}


### PR DESCRIPTION
Resolves #12

When `r.Body.Close()` fails in `ServeHTTP`, the handler returns without writing any HTTP response, causing the client to receive a connection reset or empty response. This adds an explicit 500 error response before the return.