### PR TITLE
fix(proxy): enforce max body size with MaxBytesReader to prevent OOM

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -39,6 +39,8 @@ import (
 	"github.com/karthikeyansura/ha-l7-lb/internal/repository"
 )
 
+const maxBodySize = 10 << 20 // 10 MB payload limit to prevent OOM on buffered retries
+
 // ReverseProxy implements http.Handler. Each incoming request is routed
 // to a backend, proxied, and optionally retried on failure.
 type ReverseProxy struct {
@@ -75,8 +77,14 @@ func (lb *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var bodyBytes []byte
 	var err error
 	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 		bodyBytes, err = io.ReadAll(r.Body)
 		if err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "Request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
 			http.Error(w, "Failed to read request body", http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
Resolves #8

The proxy buffers the entire request body into memory for retry replay. With 512MB ECS Fargate tasks, a burst of large payloads causes OOM kills. This adds `http.MaxBytesReader` with a 10MB cap. Requests exceeding the limit receive 413 Request Entity Too Large.