### PR TITLE
fix(proxy): use configured timeout instead of hardcoded 2s

### DIFF
--- a/cmd/lb/main.go
+++ b/cmd/lb/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	// Construct the reverse proxy. updater may be nil in degraded mode;
 	// the proxy already nil-checks before calling it.
-	lb := proxy.NewReverseProxy(sharedState, policy, collector, updater)
+	lb := proxy.NewReverseProxy(sharedState, policy, collector, updater, config.AppConfig.LoadBalancer.Timeout)
 
 	// Health checker: periodic /health GETs against all backends.
 	// In degraded mode, updater is nil — checker will update local state only.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -49,15 +49,17 @@ type ReverseProxy struct {
 	collector *metrics.Collector     // Request-level metrics accumulator.
 	updater   health.StatusUpdater   // Redis-backed health state propagator.
 	transport http.RoundTripper      // HTTP transport for backend requests.
+	timeout   time.Duration          // Backend request timeout from config.
 }
 
 // NewReverseProxy constructs a proxy wired to all subsystems.
-func NewReverseProxy(pool repository.SharedState, algorithm algorithms.Rule, collector *metrics.Collector, updater health.StatusUpdater) *ReverseProxy {
+func NewReverseProxy(pool repository.SharedState, algorithm algorithms.Rule, collector *metrics.Collector, updater health.StatusUpdater, timeout time.Duration) *ReverseProxy {
 	return &ReverseProxy{
 		pool:      pool,
 		algo:      algorithm,
 		collector: collector,
 		updater:   updater,
+		timeout:   timeout,
 		transport: &http.Transport{
 			MaxIdleConns:        100,
 			MaxIdleConnsPerHost: 20,
@@ -192,7 +194,7 @@ func (lb *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // goroutines indefinitely. On timeout, a typed TimeoutError is returned
 // so callers can distinguish timeouts from connection failures.
 func (lb *ReverseProxy) proxyRequest(w http.ResponseWriter, r *http.Request, destURL *url.URL) error {
-	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), lb.timeout)
 	defer cancel()
 
 	// Clone request with the timeout context.


### PR DESCRIPTION
Resolves #11

The proxy ignores `config.yaml`'s `load_balancer.timeout: 5s` and hardcodes a 2-second timeout in `proxyRequest`. Operators cannot tune timeouts for slower workloads, and chaos delay experiments are capped at 2s.

This adds a `timeout` field to `ReverseProxy`, injected at construction time from the parsed config, and uses it in `proxyRequest`.