### PR TITLE
feat(repo): add connection draining state for graceful backend removal

### DIFF
--- a/internal/repository/in_memory.go
+++ b/internal/repository/in_memory.go
@@ -120,6 +120,11 @@ func (i *InMemory) SyncServers(activeURLs []url.URL, defaultWeight int) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
+	activeSet := make(map[string]bool, len(activeURLs))
+	for _, u := range activeURLs {
+		activeSet[u.String()] = true
+	}
+
 	newServers := make([]*ServerState, 0, len(activeURLs))
 	existingMap := make(map[string]*ServerState)
 
@@ -130,19 +135,30 @@ func (i *InMemory) SyncServers(activeURLs []url.URL, defaultWeight int) {
 	for _, u := range activeURLs {
 		urlStr := u.String()
 		if existing, found := existingMap[urlStr]; found {
-			// Preserve existing state (connections, health)
+			existing.SetDraining(false)
 			newServers = append(newServers, existing)
 		} else {
-			// Add new dynamically scaled backend
 			s := &ServerState{
 				ServerURL:         u,
 				Weight:            defaultWeight,
 				LastCheck:         time.Now(),
 				ActiveConnections: 0,
 			}
-			s.SetHealthy(true) // Assume healthy until proven otherwise
+			s.SetHealthy(true)
 			newServers = append(newServers, s)
 		}
 	}
+
+	// Backends no longer in DNS: drain rather than drop immediately.
+	for _, s := range i.servers {
+		if !activeSet[s.ServerURL.String()] {
+			if s.GetActiveConnections() > 0 {
+				s.SetDraining(true)
+				s.SetHealthy(false)
+				newServers = append(newServers, s)
+			}
+		}
+	}
+
 	i.servers = newServers
 }

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -14,10 +14,11 @@ import (
 // ActiveConnections is similarly managed via atomic operations.
 type ServerState struct {
 	ServerURL         url.URL
-	Weight            int        // Base weight assigned to the backend.
+	Weight            int         // Base weight assigned to the backend.
 	Healthy           atomic.Bool // Atomic. Read lock-free by health checker and proxy.
-	LastCheck         time.Time  // Guarded by InMemory.mu. Timestamp of last health state change.
-	ActiveConnections int64      `redis:"active_connections"` // Atomic. Tracks in-flight proxied requests.
+	LastCheck         time.Time   // Guarded by InMemory.mu. Timestamp of last health state change.
+	ActiveConnections int64       `redis:"active_connections"` // Atomic. Tracks in-flight proxied requests.
+	Draining          atomic.Bool // Atomic. True when backend is being removed but has in-flight requests.
 }
 
 // IsHealthy returns the current health status using an atomic load.
@@ -43,4 +44,16 @@ func (s *ServerState) GetActiveConnections() int64 {
 // when multiple proxy goroutines modify the same backend concurrently.
 func (s *ServerState) AddConnections(connections int64) {
 	atomic.AddInt64(&s.ActiveConnections, connections)
+}
+
+// IsDraining returns whether this backend is in connection-draining state.
+// A draining backend accepts no new requests but completes in-flight ones.
+func (s *ServerState) IsDraining() bool {
+	return s.Draining.Load()
+}
+
+// SetDraining marks this backend as draining (being removed from DNS)
+// using an atomic store.
+func (s *ServerState) SetDraining(draining bool) {
+	s.Draining.Store(draining)
 }


### PR DESCRIPTION
Resolves #10

When DNS removes a backend IP during scale-down, `SyncServers` immediately drops it from the pool, severing any in-flight requests. This implements a draining state: removed backends are marked unhealthy (no new traffic) but remain in the pool until their active connections reach zero.