### PR TITLE
fix(health): skip probing draining backends and log drain completion

### DIFF
--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -93,9 +93,15 @@ func (hc *Checker) checkAll() {
 // within the configured timeout. Any other outcome (error, non-200 status,
 // timeout) marks the backend as DOWN.
 //
+// Draining backends are skipped entirely: they are already marked unhealthy
+// and are waiting for in-flight connections to complete before removal.
+//
 // State changes only: if the probed status matches the current Healthy flag,
 // no update is published. This minimizes Redis write frequency.
 func (hc *Checker) checkBackend(backend *repository.ServerState) {
+	if backend.IsDraining() {
+		return
+	}
 	serverURL := backend.ServerURL.String() + "/health"
 	resp, err := hc.client.Get(serverURL)
 

--- a/internal/repository/in_memory.go
+++ b/internal/repository/in_memory.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"log/slog"
 	"net/url"
 	"sync"
 	"time"
@@ -150,12 +151,17 @@ func (i *InMemory) SyncServers(activeURLs []url.URL, defaultWeight int) {
 	}
 
 	// Backends no longer in DNS: drain rather than drop immediately.
+	// Backends with active connections are kept as draining and unhealthy.
+	// Backends whose connections have drained to 0 are removed from the pool.
 	for _, s := range i.servers {
 		if !activeSet[s.ServerURL.String()] {
 			if s.GetActiveConnections() > 0 {
 				s.SetDraining(true)
 				s.SetHealthy(false)
 				newServers = append(newServers, s)
+			} else if s.IsDraining() {
+				slog.Info("Draining backend removed (connections drained to 0)",
+					"backend", s.ServerURL.String())
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
The `Draining` field on `ServerState` is set in `SyncServers` but never read, making `IsDraining()` dead code. Worse, the health checker continues probing draining backends; if the backend is still responding, it gets re-marked healthy, which contradicts the draining intent. This PR integrates the draining state into the health checker to skip probing draining backends, and into `SyncServers` to log when a draining backend's connections reach 0 and it is removed from the pool.

## Changes
- `internal/health/checker.go`: Add early return in `checkBackend` to skip probing for draining backends.
- `internal/repository/in_memory.go`: Add `log/slog` import and log a message when a draining backend completes drainage and is reaped.

Resolves #52