### PR TITLE
fix(proxy): only record timeout=true when error is actually a TimeoutError

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -219,7 +219,9 @@ func (lb *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Both attempts failed, or method is non-idempotent.
-	lb.collector.RecordRequest(backendURL.String(), time.Since(startTime), false, true, false)
+	var timeoutErr TimeoutError
+	isTimeout := errors.As(err, &timeoutErr)
+	lb.collector.RecordRequest(backendURL.String(), time.Since(startTime), false, isTimeout, false)
 	http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
 }
 


### PR DESCRIPTION
## Summary
The terminal failure path in `ServeHTTP` unconditionally passes `timeout=true` to `RecordRequest`, inflating `BackendMetrics.TimeoutCount` for non-timeout failures (5xx `BackendError`, connection refused, retry budget exceeded). This distorts experiment analytics. This inspects the actual error type using `errors.As` and only sets the timeout flag when the error is a `TimeoutError`.

## Changes
- `internal/proxy/proxy.go`: Replace hardcoded `true` with `errors.As` type check on the error at the terminal failure path.

Resolves #48