### PR TITLE
feat(discovery): support per-endpoint weights with multi-source DNS watchers

### DIFF
--- a/cmd/lb/main.go
+++ b/cmd/lb/main.go
@@ -13,7 +13,7 @@
 //  1. Load config (YAML + REDIS_ADDR env override).
 //  2. Parse base target URL and instantiate the routing algorithm.
 //  3. Create empty InMemory shared state.
-//  4. Start Dynamic DNS Discovery in a background goroutine to populate the state.
+//  4. Start one DNS watcher per configured backend endpoint.
 //  5. Connect to Redis; if unavailable, degrade to local-only health mode.
 //  6. Sync local state from Redis (handles LB restart scenarios).
 //  7. Start periodic re-sync ticker (heals missed Pub/Sub events).
@@ -29,6 +29,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -78,31 +79,30 @@ func main() {
 		return
 	}
 
-	// Extract the base Cloud Map target from the first configured backend
 	if len(route.Backends) == 0 {
 		slog.Error("At least one backend must be configured to extract the discovery domain.")
 		return
 	}
-	baseTarget, err := url.Parse(route.Backends[0].Endpoint)
-	if err != nil {
-		slog.Error("Invalid backend endpoint URL format", "error", err)
-		return
-	}
 
-	hostname := baseTarget.Hostname()
-	port := baseTarget.Port()
-	scheme := baseTarget.Scheme
-	defaultWeight := route.Backends[0].Weight
-
-	// Initialize with an empty pool; the DNS worker will populate it immediately.
+	// Initialize with an empty pool; DNS watchers will populate it immediately.
 	sharedState := repository.NewInMemory([]url.URL{}, []int{})
 
 	// Cancellable context for all background goroutines — cancelled on SIGTERM/SIGINT.
 	ctx, cancelAll := context.WithCancel(context.Background())
 	defer cancelAll()
 
-	// Start Dynamic DNS Discovery in a background goroutine
-	discovery.StartDNSWatcher(ctx, hostname, port, scheme, defaultWeight, sharedState)
+	// Start one DNS watcher per configured backend endpoint.
+	// Each watcher resolves its hostname independently and syncs with its own
+	// weight, enabling heterogeneous backends (e.g., strong/weak) for weighted RR.
+	for _, backend := range route.Backends {
+		target, err := url.Parse(backend.Endpoint)
+		if err != nil {
+			slog.Error("Invalid backend endpoint URL format", "endpoint", backend.Endpoint, "error", err)
+			return
+		}
+		discovery.StartDNSWatcher(ctx, target.Hostname(), target.Hostname(), target.Port(), target.Scheme, backend.Weight, sharedState)
+		slog.Info("DNS watcher started", "hostname", target.Hostname(), "weight", backend.Weight)
+	}
 
 	// Redis is optional: if unavailable, the LB runs in degraded mode
 	// with local-only health state (no cross-instance sync).
@@ -182,10 +182,9 @@ func main() {
 	setupGracefulShutdown(collector, *metricsOut, server, metricsServer, cancelAll, done)
 
 	slog.Info(fmt.Sprintf("Load balancer starting on %s with %s policy", addr, route.Policy))
-	slog.Info(fmt.Sprintf("Base discovery target: %s", route.Backends[0].Endpoint))
 	slog.Info(fmt.Sprintf("Metrics available at http://localhost:%d/metrics", config.AppConfig.LoadBalancer.Port+1000))
 
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal(err)
 	}
 
@@ -256,7 +255,7 @@ func startMetricsServer(collector *metrics.Collector, pool repository.SharedStat
 	addr := fmt.Sprintf(":%d", port)
 	srv := &http.Server{Addr: addr, Handler: mux}
 	go func() {
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			slog.Error(fmt.Sprintf("Metrics server error: %v", err))
 		}
 	}()

--- a/internal/discovery/dns.go
+++ b/internal/discovery/dns.go
@@ -14,29 +14,32 @@ import (
 	"github.com/karthikeyansura/ha-l7-lb/internal/repository"
 )
 
-// StartDNSWatcher periodically resolves the target DNS name and updates the shared pool.
-func StartDNSWatcher(ctx context.Context, targetHostname, port, scheme string, defaultWeight int, pool repository.SharedState) {
+// StartDNSWatcher periodically resolves the target DNS name and updates
+// the shared pool. Each watcher is scoped by sourceTag so multiple DNS
+// sources (e.g., api-strong.internal and api-weak.internal) can coexist
+// without overwriting each other's backends.
+func StartDNSWatcher(ctx context.Context, sourceTag, targetHostname, port, scheme string, weight int, pool repository.SharedState) {
 	ticker := time.NewTicker(5 * time.Second)
 	go func() {
 		defer ticker.Stop()
 
-		syncDNS(targetHostname, port, scheme, defaultWeight, pool)
+		syncDNS(sourceTag, targetHostname, port, scheme, weight, pool)
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				syncDNS(targetHostname, port, scheme, defaultWeight, pool)
+				syncDNS(sourceTag, targetHostname, port, scheme, weight, pool)
 			}
 		}
 	}()
 }
 
 // syncDNS performs a single DNS lookup and synchronizes the active IP addresses
-// with the shared repository pool. It preserves the state of existing connections
-// while adding new tasks and pruning dead ones.
-func syncDNS(hostname, port, scheme string, defaultWeight int, pool repository.SharedState) {
+// with the shared repository pool. Only backends belonging to the given sourceTag
+// are affected; other sources' backends are preserved.
+func syncDNS(sourceTag, hostname, port, scheme string, weight int, pool repository.SharedState) {
 	ips, err := net.LookupIP(hostname)
 	if err != nil {
 		slog.Warn("DNS lookup failed (cluster might be scaling to 0 or DNS unavailable)", "host", hostname, "error", err)
@@ -52,6 +55,6 @@ func syncDNS(hostname, port, scheme string, defaultWeight int, pool repository.S
 	}
 
 	if len(activeURLs) > 0 {
-		pool.SyncServers(activeURLs, defaultWeight)
+		pool.SyncServersBySource(sourceTag, activeURLs, weight)
 	}
 }

--- a/internal/repository/in_memory.go
+++ b/internal/repository/in_memory.go
@@ -168,3 +168,68 @@ func (i *InMemory) SyncServers(activeURLs []url.URL, defaultWeight int) {
 
 	i.servers = newServers
 }
+
+// SyncServersBySource reconciles the pool for a single DNS source.
+// Only servers with a matching SourceTag are affected; other sources'
+// servers are preserved. This enables multiple DNS watchers (e.g.,
+// api-strong.internal and api-weak.internal) to coexist in one pool
+// without overwriting each other.
+func (i *InMemory) SyncServersBySource(sourceTag string, activeURLs []url.URL, weight int) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	activeSet := make(map[string]bool, len(activeURLs))
+	for _, u := range activeURLs {
+		activeSet[u.String()] = true
+	}
+
+	existingMap := make(map[string]*ServerState)
+	for _, s := range i.servers {
+		if s.SourceTag == sourceTag {
+			existingMap[s.ServerURL.String()] = s
+		}
+	}
+
+	// Keep all servers from OTHER sources untouched.
+	newServers := make([]*ServerState, 0, len(i.servers))
+	for _, s := range i.servers {
+		if s.SourceTag != sourceTag {
+			newServers = append(newServers, s)
+		}
+	}
+
+	// Add/update servers for THIS source.
+	for _, u := range activeURLs {
+		urlStr := u.String()
+		if existing, found := existingMap[urlStr]; found {
+			existing.SetDraining(false)
+			newServers = append(newServers, existing)
+		} else {
+			s := &ServerState{
+				ServerURL:         u,
+				Weight:            weight,
+				LastCheck:         time.Now(),
+				ActiveConnections: 0,
+				SourceTag:         sourceTag,
+			}
+			s.SetHealthy(true)
+			newServers = append(newServers, s)
+		}
+	}
+
+	// Drain removed backends from this source.
+	for _, s := range i.servers {
+		if s.SourceTag == sourceTag && !activeSet[s.ServerURL.String()] {
+			if s.GetActiveConnections() > 0 {
+				s.SetDraining(true)
+				s.SetHealthy(false)
+				newServers = append(newServers, s)
+			} else if s.IsDraining() {
+				slog.Info("Draining backend removed (connections drained to 0)",
+					"backend", s.ServerURL.String(), "source", sourceTag)
+			}
+		}
+	}
+
+	i.servers = newServers
+}

--- a/internal/repository/in_memory_test.go
+++ b/internal/repository/in_memory_test.go
@@ -281,3 +281,90 @@ func TestSyncServers_ReapsDrainedBackend(t *testing.T) {
 		t.Errorf("expected backend1, got %s", servers[0].ServerURL.String())
 	}
 }
+
+func TestSyncServersBySource_MultipleSourcesCoexist(t *testing.T) {
+	pool := NewInMemory([]url.URL{}, []int{})
+
+	strongURLs := []url.URL{mustURL("http://10.0.1.1:8080"), mustURL("http://10.0.1.2:8080")}
+	weakURLs := []url.URL{mustURL("http://10.0.2.1:8080"), mustURL("http://10.0.2.2:8080")}
+
+	pool.SyncServersBySource("strong", strongURLs, 70)
+	pool.SyncServersBySource("weak", weakURLs, 30)
+
+	servers, _ := pool.GetAllServers()
+	if len(servers) != 4 {
+		t.Fatalf("expected 4 servers (2 strong + 2 weak), got %d", len(servers))
+	}
+
+	weights := map[string]int{}
+	for _, s := range servers {
+		weights[s.ServerURL.String()] = s.Weight
+	}
+	if weights["http://10.0.1.1:8080"] != 70 {
+		t.Errorf("expected strong weight 70, got %d", weights["http://10.0.1.1:8080"])
+	}
+	if weights["http://10.0.2.1:8080"] != 30 {
+		t.Errorf("expected weak weight 30, got %d", weights["http://10.0.2.1:8080"])
+	}
+}
+
+func TestSyncServersBySource_DoesNotOverwriteOtherSource(t *testing.T) {
+	pool := NewInMemory([]url.URL{}, []int{})
+
+	strongURLs := []url.URL{mustURL("http://10.0.1.1:8080")}
+	weakURLs := []url.URL{mustURL("http://10.0.2.1:8080")}
+
+	pool.SyncServersBySource("strong", strongURLs, 70)
+	pool.SyncServersBySource("weak", weakURLs, 30)
+
+	// Re-sync strong with a different set — weak should be untouched.
+	newStrongURLs := []url.URL{mustURL("http://10.0.1.3:8080")}
+	pool.SyncServersBySource("strong", newStrongURLs, 70)
+
+	servers, _ := pool.GetAllServers()
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers (1 new strong + 1 weak), got %d", len(servers))
+	}
+
+	found := map[string]bool{}
+	for _, s := range servers {
+		found[s.ServerURL.String()] = true
+	}
+	if !found["http://10.0.1.3:8080"] {
+		t.Error("new strong backend should be present")
+	}
+	if !found["http://10.0.2.1:8080"] {
+		t.Error("weak backend should be preserved across strong re-sync")
+	}
+}
+
+func TestSyncServersBySource_DrainsRemovedBackend(t *testing.T) {
+	pool := NewInMemory([]url.URL{}, []int{})
+
+	urls := []url.URL{mustURL("http://10.0.1.1:8080"), mustURL("http://10.0.1.2:8080")}
+	pool.SyncServersBySource("strong", urls, 70)
+
+	// Add connections to the second backend.
+	pool.AddConnections(mustURL("http://10.0.1.2:8080"), 5)
+
+	// Re-sync strong with only the first — second should drain.
+	pool.SyncServersBySource("strong", []url.URL{mustURL("http://10.0.1.1:8080")}, 70)
+
+	servers, _ := pool.GetAllServers()
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers (1 active + 1 draining), got %d", len(servers))
+	}
+
+	for _, s := range servers {
+		if s.ServerURL.String() == "http://10.0.1.2:8080" {
+			if !s.IsDraining() {
+				t.Error("removed backend with active connections should be draining")
+			}
+			if s.IsHealthy() {
+				t.Error("draining backend should be unhealthy")
+			}
+			return
+		}
+	}
+	t.Error("draining backend should still be in pool")
+}

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -41,4 +41,11 @@ type SharedState interface {
 	// via DNS and removes IPs that no longer exist, while preserving the active
 	// connections and health status of existing servers.
 	SyncServers(activeURLs []url.URL, defaultWeight int)
+
+	// SyncServersBySource reconciles the pool for a single DNS source.
+	// Only servers with a matching sourceTag are affected; other sources'
+	// servers are preserved. This enables multiple DNS watchers (e.g.,
+	// api-strong.internal and api-weak.internal) to coexist in one pool
+	// without overwriting each other.
+	SyncServersBySource(sourceTag string, activeURLs []url.URL, weight int)
 }

--- a/internal/repository/models.go
+++ b/internal/repository/models.go
@@ -19,6 +19,7 @@ type ServerState struct {
 	LastCheck         time.Time   // Guarded by InMemory.mu. Timestamp of last health state change.
 	ActiveConnections int64       `redis:"active_connections"` // Atomic. Tracks in-flight proxied requests.
 	Draining          atomic.Bool // Atomic. True when backend is being removed but has in-flight requests.
+	SourceTag         string      // DNS source that discovered this backend (e.g., "api-strong.internal").
 }
 
 // IsHealthy returns the current health status using an atomic load.


### PR DESCRIPTION
## Summary

`SyncServers` assigns `defaultWeight` from the first config entry to all backends discovered via DNS. When strong and weak backends resolve from the same hostname, they all get the same weight, making weighted RR identical to unweighted.

This adds multi-source DNS discovery so each `config.yaml` backend entry starts its own DNS watcher with its own weight. A new `SyncServersBySource` method scopes pool updates by source tag, preventing multiple watchers from overwriting each other's backends.

## Changes

- `internal/repository/models.go`: Add `SourceTag` field to `ServerState`.
- `internal/repository/interface.go`: Add `SyncServersBySource` to `SharedState` interface.
- `internal/repository/in_memory.go`: Implement `SyncServersBySource` with source-scoped sync and draining logic.
- `internal/repository/in_memory_test.go`: Add tests for multi-source coexistence, overwrite protection, and draining.
- `internal/discovery/dns.go`: Accept `sourceTag` and `weight` parameters; call `SyncServersBySource` instead of `SyncServers`.
- `cmd/lb/main.go`: Loop over all `route.Backends` entries and start one DNS watcher per endpoint with its configured weight.

## Backwards Compatibility

Single-entry `config.yaml` (used for RR and LC experiments) works identically — one iteration of the loop, one watcher. Existing `SyncServers` is unchanged.

## Weighted Experiment Config (runtime change, not in this PR)

```yaml
route:
  policy: "weighted"
  backends:
    - endpoint: "http://api-strong.internal:8080"
      weight: 70
    - endpoint: "http://api-weak.internal:8080"
      weight: 30
```

Resolves #64